### PR TITLE
Changed Markdown.Editor.js to be friendly with Rails id-based parameter paradigm.

### DIFF
--- a/vendor/assets/javascripts/markdown.editor.js
+++ b/vendor/assets/javascripts/markdown.editor.js
@@ -249,8 +249,6 @@
     function PanelCollection(postfix) {
         this.buttonBar = doc.getElementById("wmd-button-bar" + postfix);
         this.preview = doc.getElementById("wmd-preview" + postfix);
-        // this.input = doc.getElementById("wmd-input" + postfix);
-        alert(doc.getElementsByClassName("wmd-input" + postfix));
         this.input = doc.getElementsByClassName("wmd-input" + postfix)[0];
     };
 


### PR DESCRIPTION
PageDown utilizes the ID attribute for particular elements in order to setup various "panels".  One of these panels is the input panel.  It grabs the id for a text area element and uses that as the markdown input.

The library expects a text area with the id of `wmd-input` to be the element which receives the markdown input from the user.  This is problematic, especially if you want a particular model's field to be the markdown input (since it already has it's id assigned by Rails naming convention).

To fix this, I modified the PanelCollection function within Markdown.Editor.  I changed the DOM element being searched for the input to match a particular class name rather than a particular id.  This eliminates the id conflict with Rails' naming conventions.

Here's the Stack Overflow conversation where the fork and change originated from http://stackoverflow.com/questions/13792956/change-existing-javascript-object-functions-with-prototype
